### PR TITLE
Allow listing of available chromecasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,13 @@
 ```pip install startcast```
 
 ## Usage:
+Run an app on a given chromecast
 ```startcast CHROMECAST_FRIENDLY_NAME APP_ID```
+
+List chromecasts
+```startcast -l```
+
+Show usage statement
+```startcast --help```
+or run it without arguments to see the usage statement
+```startcast```

--- a/startcast/__init__.py
+++ b/startcast/__init__.py
@@ -5,8 +5,15 @@ def main():
     import pychromecast
     import sys
     
-    if sys.argv[1] == "--help":
-        print "Usage: startcast CHROMECAST_FRIENDLY_NAME APP_ID"
+    if len(sys.argv) == 1 or sys.argv[1] == "--help":
+        print "Usage: startcast [-l] [--help] [CHROMECAST_FRIENDLY_NAME] [APP_ID]"
+        print "  -l                               show list of available chromeasts"
+        print "  --help                           show help text"
+        print "  CHROMECAST_FRIENDLY_NAME APP_ID  play APPID on a named chromecast"
+        exit(0)
+
+    if sys.argv[1] == "-l":
+        print "\n".join(pychromecast.get_chromecasts_as_dict().keys())
         exit(0)
         
     try:


### PR DESCRIPTION
1. -l flag shows available chromcasts
2. running startcast without any arguments/flags shows the usage statement
3. update the README.md to reflect the new functionality
